### PR TITLE
fix cached media property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-janus",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "React - Redux based wrapper for Janus, enhanced and based on the original (old) fork",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",

--- a/src/containers/VideoRoom.js
+++ b/src/containers/VideoRoom.js
@@ -124,6 +124,7 @@ function selector(state) {
   const {
     addedFeed
   } = state.videoRoom
+  const { media, ...janusConfig } = state.janusConfig
   const error = state.mcu.error || state.videoRoom.error || null
   return Object.assign({
     janusInstance,
@@ -132,7 +133,7 @@ function selector(state) {
       countdown: 5000
     },
     error
-  }, state.janusConfig)
+  }, janusConfig)
 }
 
 export default connect(selector)(VideoRoom)


### PR DESCRIPTION
That PR should fix the case, when media property is stored once inside storage of video room container, and then won't update during page is life, because it gonna be overridden by `connect` function.